### PR TITLE
Remove estree-walk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "convert-source-map": "^1.5.0",
     "end-of-stream": "^1.4.0",
     "estree-is-require": "^1.0.0",
-    "estree-walk": "^2.2.0",
     "fastify": "^1.2.1",
     "fastify-static": "^0.9.0",
     "flush-write-stream": "^1.0.2",


### PR DESCRIPTION
I'm in the process of deprecating `estree-walk` because there is fine substitutes.

It doesn't look like its used in this project anyways? I went ahead and removed it without any other changes, but I'm not sure this is okay.

Using `npx depcheck` it seems there is other unused dependencies too.